### PR TITLE
fix(django_media_fixtures): correct system checks requirement in collectmedia command

### DIFF
--- a/django_media_fixtures/management/commands/collectmedia.py
+++ b/django_media_fixtures/management/commands/collectmedia.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             MEDIA_FIXTURE_FOLDERNAME = 'media_fixtures'
     """
     help = "Collect media (fixtures) files in a single location."
-    requires_system_checks = False
+    requires_system_checks = []
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Removed the `requires_system_checks` boolean flag and replaced it with an empty list to align with Django's expected format for command options. This change ensures compatibility with Django's command infrastructure and avoids potential issues with system checks being improperly bypassed or enforced.