### PR TITLE
Modified a specific line that was causing issue in Django versions >=4.1

### DIFF
--- a/django_media_fixtures/management/commands/collectmedia.py
+++ b/django_media_fixtures/management/commands/collectmedia.py
@@ -29,6 +29,8 @@ class Command(BaseCommand):
             MEDIA_FIXTURE_FOLDERNAME = 'media_fixtures'
     """
     help = "Collect media (fixtures) files in a single location."
+    
+    """Modified the following line to resolve 'typeerror: requires_system_checks must be a list or tuple' for users facing issues in django versions >= 4.1"""
     # requires_system_checks = False
     requires_system_checks = []
 

--- a/django_media_fixtures/management/commands/collectmedia.py
+++ b/django_media_fixtures/management/commands/collectmedia.py
@@ -29,7 +29,8 @@ class Command(BaseCommand):
             MEDIA_FIXTURE_FOLDERNAME = 'media_fixtures'
     """
     help = "Collect media (fixtures) files in a single location."
-    requires_system_checks = False
+    # requires_system_checks = False
+    requires_system_checks = []
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Here is the issue 

''typeerror: requires_system_checks must be a list or tuple'' that users are facing specific to this line in Django versions >=4.1

https://github.com/adrianoveiga/django-media-fixtures/blob/master/django_media_fixtures/management/commands/collectmedia.py#L25C5-L25C27

Modified the line to an empty list instead of a Boolean value by commenting out the earlier one.


